### PR TITLE
added slugPath variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ plugins: [
          path: './src/pages', // Path to markdown files to be converted to pages
          templatePath: './src/templates', // Path to page templates
          template: 'default', // Default template to use if none is supplied
+         slugPath: 'content/posts', // This would make all pages be located at /content/posts/...
       }
    }
 ]

--- a/src/create-pages.js
+++ b/src/create-pages.js
@@ -41,6 +41,8 @@ module.exports = async ({ graphql, boundActionCreators }, userOptions) => {
 		let { fileAbsolutePath, fields } = edges[i].node
 		let { template, slug } = fields
 
+		slug = `${options.slugPath || ''}${slug}`
+
 		let component = await findTemplate(template, options)
 		createPage({
 			path: slug,

--- a/src/default-options.js
+++ b/src/default-options.js
@@ -2,6 +2,7 @@ const options = {
 	path: `./src/pages`,
 	templatePath: `./src/templates`,
 	template: `default`,
+	slugPath: ``,
 }
 
 module.exports = options


### PR DESCRIPTION
One of the problems that I ran into was that I had some markdown pages at e.g. `/content/posts/2018/12/19/my-post.md` and this meant that the resulting URL was `https://example.com/2018/12/19/my-post` but I really wanted it to be `https://example.com/posts/2018/12/19/my-post`.

This feature means that people can specify a URL prefix for their pages.